### PR TITLE
check for vlc automatically in wscript

### DIFF
--- a/wscript
+++ b/wscript
@@ -8,11 +8,13 @@ def set_options(opt):
 def configure(conf):
   conf.check_tool("compiler_cxx")
   conf.check_tool("node_addon")
-  conf.env.append_value("LIBPATH", "/Applications/VLC.app/Contents/MacOS/lib")
-  conf.env.append_value("LIB", "vlc.5")
+  conf.check(lib='vlc', uselib_store='VLC')
+  #conf.env.append_value("LIBPATH", "/Applications/VLC.app/Contents/MacOS/lib")
+  #conf.env.append_value("LIB", "vlc.5")
    
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")
-  obj.cxxflags = ["-D_FILE_OFFSET_BITS=64", "-D_LARGEFILE_SOURCE", "-I/Applications/VLC.app/Contents/MacOS/include"]
+  #obj.cxxflags = ["-D_FILE_OFFSET_BITS=64", "-D_LARGEFILE_SOURCE"]
+  obj.uselib = ['VLC']
   obj.target = "naudio"
   obj.source = "naudio.cc"


### PR DESCRIPTION
this should do the trick. I followed some example doing the same for other libraries. It works for me, at least the configure part. I can't get it to compile because of conflicting versions of libvlc on Ubuntu Lucid. There is a way to check for the version as well but since I can't find which version you're using I didn't add it.
